### PR TITLE
fix duplicate npm publishing issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: uvic-course-scraper
 
 on:
   push:
-    branches: [ master, fix/auto-npm-publishing ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -93,7 +93,7 @@ jobs:
           verbose: true # optional (default = false)
 
   publish-npm:
-    if: github.ref != 'refs/heads/master' && github.actor != 'isaaccormack'
+    if: github.ref == 'refs/heads/master' && github.actor != 'vikelabs-bot'
     needs: [ lint, build, test ]
     environment: deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: uvic-course-scraper
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix/auto-npm-publishing ]
   pull_request:
     branches: [ master ]
 
@@ -93,7 +93,7 @@ jobs:
           verbose: true # optional (default = false)
 
   publish-npm:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref != 'refs/heads/master' && github.actor != 'isaaccormack'
     needs: [ lint, build, test ]
     environment: deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
           verbose: true # optional (default = false)
 
   publish-npm:
-    if: github.ref == 'refs/heads/master' && github.actor != 'vikelabs-bot'
+    if: github.ref == 'refs/heads/master' && github.actor == 'vikelabs-bot'
     needs: [ lint, build, test ]
     environment: deployment
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Contributors][contributors-shield]][contributors-url]
 [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
+![npm][npm-shield]
 [![Code Coverage][coverage-shield]][coverage-url]
 
 # uvic-course-scraper
@@ -142,5 +143,6 @@ This contains detailed information about a class like:
 [stars-url]: https://github.com/VikeLabs/uvic-course-scraper/stargazers
 [issues-shield]: https://img.shields.io/github/issues/VikeLabs/uvic-course-scraper.svg?style=flat-square
 [issues-url]: https://github.com/othneildrew/VikeLabs/uvic-course-scraper/issues
+[npm-shield]: https://img.shields.io/npm/v/@vikelabs/uvic-course-scraper?style=flat-square
 [coverage-shield]: https://codecov.io/gh/VikeLabs/uvic-course-scraper/branch/master/graph/badge.svg?token=06B7FNZ8TH
 [coverage-url]: https://codecov.io/gh/VikeLabs/uvic-course-scraper

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vikelabs/uvic-course-scraper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "UVic Course Scrapper",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
- Dont run npm-publish when the github actor is vikelabs-bot (this fixes our double publishing problem)
- Rest of the workflow will still run twice (lint, build, and test)

Don't think there is a way to conditionally run the whole workflow so I just added this on the critical step. Could add this on all steps if we want? Works as is. 